### PR TITLE
vl_compile_nn should be vl_compilenn

### DIFF
--- a/run_ICL.m
+++ b/run_ICL.m
@@ -53,7 +53,7 @@ catch
     curr_path = pwd;
     cd(fileparts(which('vl_compilenn')));
     try
-        vl_compile_nn
+        vl_compilenn
         cd(curr_path)
         disp(['MEX-files successfully compiled. Attempting to run ICLabel again. ' ...
             'Please consider emailing Luca Pion-Tonachini at lpionton@ucsd.edu to ' ...


### PR DESCRIPTION
afaik exists no function "vl_compile_nn" in matconvnet